### PR TITLE
Fix FormatException thrown in MoneyMaskedTextController

### DIFF
--- a/lib/flutter_masked_text2.dart
+++ b/lib/flutter_masked_text2.dart
@@ -131,7 +131,7 @@ class MoneyMaskedTextController extends TextEditingController {
     _validateConfig();
 
     this.addListener(() {
-      this.updateValue(this.numberValue ?? 0);
+      this.updateValue(this.numberValue ?? initialValue);
       this.afterChange(this.text, this.numberValue);
     });
 

--- a/lib/flutter_masked_text2.dart
+++ b/lib/flutter_masked_text2.dart
@@ -131,7 +131,7 @@ class MoneyMaskedTextController extends TextEditingController {
     _validateConfig();
 
     this.addListener(() {
-      this.updateValue(this.numberValue);
+      this.updateValue(this.numberValue ?? 0);
       this.afterChange(this.text, this.numberValue);
     });
 
@@ -176,13 +176,13 @@ class MoneyMaskedTextController extends TextEditingController {
     }
   }
 
-  double get numberValue {
+  double? get numberValue {
     List<String> parts =
         _getOnlyNumbers(this.text).split('').toList(growable: true);
 
     parts.insert(parts.length - precision, '.');
 
-    return double.parse(parts.join());
+    return double.tryParse(parts.join());
   }
 
   _validateConfig() {


### PR DESCRIPTION
```bash
The following FormatException was thrown while dispatching notifications for MoneyMaskedTextController:

Invalid double
.

When the exception was thrown, this was the stack
#0      double.parse (dart:core-patch/double_patch.dart:111:28)
#1      MoneyMaskedTextController.numberValue
package:flutter_masked_text2/flutter_masked_text2.dart:185
#2      new MoneyMaskedTextController.<anonymous closure>
package:flutter_masked_text2/flutter_masked_text2.dart:134
#3      ChangeNotifier.notifyListeners
package:flutter/…/foundation/change_notifier.dart:308
#4      ValueNotifier.value=
package:flutter/…/foundation/change_notifier.dart:412
#5      TextEditingController.value=
package:flutter/…/widgets/editable_text.dart:186

```

#### Solution
- replaced double.parse() with double.tryParse()